### PR TITLE
fix for issue #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function parseMarkdown (node, i, parent, tree) {
     }
 
     var idMatch = value.match(/#\w+/)
-    var classMatch = value.match(/\.\w+(-)?\w+/g)
+    var classMatch = value.match(/\.(\w-?)+\w+/g)
     var attrMatch = value.match(/(?:\w*=\s*(?:(?:"[^"]*")|(?:'[^']*')|[^}\s]+))/g)
 
     if (idMatch) {

--- a/tests/simple.html
+++ b/tests/simple.html
@@ -1,1 +1,1 @@
-<p><span id="id" class="class other-class" data-key="val" data-another="example">text in the span</span></p>
+<p><span id="id" class="class other-class two-dash-class even-more-dashes-class" data-key="val" data-another="example">text in the span</span></p>

--- a/tests/simple.md
+++ b/tests/simple.md
@@ -1,1 +1,1 @@
-[text in the span]{#id .class .other-class key=val another=example}
+[text in the span]{#id .class .other-class .two-dash-class .even-more-dashes-class key=val another=example}


### PR DESCRIPTION
https://github.com/sethvincent/remark-bracketed-spans/issues/4

- updated regex to parse class names with more than 1 dash
- updated tests for 2 dashes and 3 dashes